### PR TITLE
Fix ModuleManager configs for better compatibility.

### DIFF
--- a/GameData/DecouplerShroud/DecouplerShroud.cfg
+++ b/GameData/DecouplerShroud/DecouplerShroud.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleDecouple]]
+@PART[*]:FOR[DecouplerShroud]:HAS[@MODULE[ModuleDecouple]]
 {
 	MODULE
 	{
@@ -42,7 +42,7 @@
 	}
 }
 
-@PART[stackDecouplerMini]{
+@PART[stackDecouplerMini]:FOR[DecouplerShroud]{
  	@MODULE[ModuleDecouplerShroud]{
  		%defaultBotWidth = 0.63		// assuming bent edges
 		%defaultVertOffset = 0.01
@@ -52,7 +52,7 @@
 		%topBevelSize = .02
 	}
 }
-@PART[stackSeparatorMini]{
+@PART[stackSeparatorMini]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
  		%defaultBotWidth = 0.63		// assuming bent edges
 		%defaultVertOffset = 0.01
@@ -62,7 +62,7 @@
 		%topBevelSize = .02
 	}
 }
-@PART[stackSeparatorBig]{
+@PART[stackSeparatorBig]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
 		%defaultBotWidth = 2.5
 		%defaultVertOffset = -0.01
@@ -72,7 +72,7 @@
 		%topBevelSize = .04
 	}
 }
-@PART[size3Decoupler]{
+@PART[size3Decoupler]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
 		%defaultBotWidth = 3.76
 		%defaultVertOffset = 0
@@ -82,7 +82,7 @@
 		%topBevelSize = .05
 	}
 }
-@PART[decoupler1-2]{
+@PART[decoupler1-2]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
 		%defaultBotWidth = 2.5
 		%defaultVertOffset = 0.03
@@ -92,7 +92,7 @@
 		%topBevelSize = .04
 	}
 }
-@PART[stackSeparator]{
+@PART[stackSeparator]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
 		%defaultBotWidth = 1.28
 		%defaultVertOffset = -0.04
@@ -102,7 +102,7 @@
 		%topBevelSize = .03
 	}
 }
-@PART[stackDecoupler]{
+@PART[stackDecoupler]:FOR[DecouplerShroud]{
 	@MODULE[ModuleDecouplerShroud]{
 		%defaultBotWidth = 1.28
 		%defaultVertOffset = 0.06

--- a/GameData/DecouplerShroud/DecouplerShroudPatches.cfg
+++ b/GameData/DecouplerShroud/DecouplerShroudPatches.cfg
@@ -1,13 +1,13 @@
 // Removing decoupler shrouds from part that shoudn't get one
 
 // Removing from heatshields
-@PART[*]:HAS[@MODULE[ModuleAblator]]:FINAL
+@PART[*]:NEEDS[DecouplerShroud]:AFTER[DecouplerShroud]:HAS[@MODULE[ModuleAblator]]
 {
 	!MODULE[ModuleDecouplerShroud] {}
 }
 
 // Parts that have a decoupler module, but aren't used as stack decouplers
-@PART[CargoShroud]:FINAL
+@PART[CargoShroud,CargoShorud]:NEEDS[DecouplerShroud]:AFTER[DecouplerShroud]
 {
 	!MODULE[ModuleDecouplerShroud] {}
 }


### PR DESCRIPTION
ModuleManager documentation, what exists of it, recommends that mod authors do
not use FINAL: this is reserved for the end user to have control over the
final state of the configs without deleting or altering supplied files.

Instead, it is recommended to mark patches with FOR[], and maintain patch
ordering with AFTER[], which is what I've done here.

Also, CargoShroud is a part (nosecone in Tundra kit) and CargoShorud is not a
typo, it's another part (decoupling solar panel cover for Cargo Dragon) --
which also has no business getting a decoupler shroud.